### PR TITLE
Register ores based on biome climate values

### DIFF
--- a/mapgen.lua
+++ b/mapgen.lua
@@ -1,10 +1,17 @@
+-- Register ores based on provided climate data, queued to run after all other mods are loaded
+local oreq = {}
+local function register_ore_by_climate(ore)
+	-- Queue up ore for processing after all mods are loaded
+	table.insert(oreq,ore)
+end
+
 -- Minetest Game, Mesecraft, and Others
 
 if minetest.get_modpath("default") ~= nil then
 
 -- Blue Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_blue",
 		wherein         = {"default:stone"},
@@ -24,7 +31,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Gray Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_gray",
 		wherein         = {"default:stone"},
@@ -44,7 +51,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Green Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_green",
 		wherein         = {"default:stone"},
@@ -64,7 +71,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Moss Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_moss",
 		wherein         = {"default:stone"},
@@ -84,7 +91,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Orange Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_orange",
 		wherein         = {"default:stone"},
@@ -104,7 +111,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Purple Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_purple",
 		wherein         = {"default:stone"},
@@ -124,7 +131,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Red Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_red",
 		wherein         = {"default:stone"},
@@ -144,7 +151,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Amber
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:amber",
 		wherein         = {"default:stone"},
@@ -164,7 +171,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Amazonite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:amazonite",
 		wherein         = {"default:stone"},
@@ -184,7 +191,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Amber
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:amber",
 		wherein         = {"default:stone"},
@@ -204,7 +211,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Amethyst
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:amethyst",
 		wherein         = {"default:stone"},
@@ -222,7 +229,7 @@ if minetest.get_modpath("default") ~= nil then
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:amethyst",
 		wherein         = {"default:stone"},
@@ -242,7 +249,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Basalt
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:basalt",
 		wherein         = {"default:stone"},
@@ -262,7 +269,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Columnar Basalt
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:basalt_columnar",
 		wherein         = {"default:stone"},
@@ -282,7 +289,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Calcite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:calcite",
 		wherein         = {"default:stone"},
@@ -301,7 +308,7 @@ if minetest.get_modpath("default") ~= nil then
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:calcite",
 		wherein         = {"default:sand", "default:silver_sand"},
@@ -322,7 +329,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Carnotite
 
-		minetest.register_ore({
+		register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:carnotite",
 		wherein         = {"default:stone", "default:desert_stone"},
@@ -342,7 +349,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Celestine
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:celestine",
 		wherein         = {"default:silver_sandstone"},
@@ -362,7 +369,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Citrine
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:citrine",
 		wherein         = {"default:desert_stone"},
@@ -382,7 +389,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Eudialite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:eudialite",
 		wherein         = {"default:stone"},
@@ -402,7 +409,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Gabbro
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:gabbro",
 		wherein         = {"default:stone"},
@@ -422,7 +429,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Galena
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:galena",
 		wherein         = {"default:stone", "default:sandstone", "default:desert_sandstone"},
@@ -442,7 +449,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Black Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_black",
 		wherein         = {"default:stone"},
@@ -462,7 +469,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Blue Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_blue",
 		wherein         = {"default:stone"},
@@ -482,7 +489,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Gray Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_gray",
 		wherein         = {"default:stone"},
@@ -502,7 +509,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Green Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_green",
 		wherein         = {"default:stone"},
@@ -523,7 +530,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Pink Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_pink",
 		wherein         = {"default:stone"},
@@ -543,7 +550,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Red Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_red",
 		wherein         = {"default:stone", "default:desert_stone"},
@@ -564,7 +571,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- White Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_white",
 		wherein         = {"default:stone"},
@@ -584,7 +591,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Heliodor
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:heliodor",
 		wherein         = {"default:stone"},
@@ -604,7 +611,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Howlite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:howlite",
 		wherein         = {"default:stone", "default:silver_sandstone", "default:desert_sandstone"},
@@ -624,7 +631,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Ilvaite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:ilvaite",
 		wherein         = {"default:stone", "default:desert_stone", "default:permafrost"},
@@ -644,7 +651,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Kyanite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:kyanite",
 		wherein         = {"default:stone"},
@@ -662,7 +669,7 @@ if minetest.get_modpath("default") ~= nil then
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:kyanite",
 		wherein         = {"default:silver_sand"},
@@ -682,7 +689,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Lapis Lazuli
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:lapis_lazuli",
 		wherein         = {"default:sandstone", "default:desert_stone", "default:silver_sandstone"},
@@ -702,7 +709,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Blue Limestone
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:limestone_blue",
 		wherein         = {"default:stone", "default:sand", "default:desert_sand"},
@@ -722,7 +729,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- White Limestone
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:limestone_white",
 		wherein         = {"default:stone", "default:silver_sand"},
@@ -742,7 +749,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Marble
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:marble",
 		wherein         = {"default:stone", "default:sandstone", "default:silver_sandstone"},
@@ -763,7 +770,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Mudstone
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:mudstone",
 		wherein         = {"default:stone"},
@@ -783,7 +790,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Prasiolite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:prasiolite",
 		wherein         = {"default:stone", "default:silver_sandstone"},
@@ -801,7 +808,7 @@ if minetest.get_modpath("default") ~= nil then
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:prasiolite",
 		wherein         = {"default:sand", "default:silver_sand", "default:desert_sand"},
@@ -821,7 +828,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Pumice
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:pumice",
 		wherein         = {"default:stone", "default:gravel"},
@@ -839,7 +846,7 @@ if minetest.get_modpath("default") ~= nil then
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:pumice",
 		wherein         = {"default:water_source"},
@@ -859,7 +866,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Quartz
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:quartz",
 		wherein         = {"default:stone", "default:desert_stone"},
@@ -877,7 +884,7 @@ if minetest.get_modpath("default") ~= nil then
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:quartz",
 		wherein         = {"default:sand", "default:silver_sand", "default:desert_sand"},
@@ -897,7 +904,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Rose Quartz
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:rose_quartz",
 		wherein         = {"default:stone", "default:desert_stone"},
@@ -915,7 +922,7 @@ if minetest.get_modpath("default") ~= nil then
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:rose_quartz",
 		wherein         = {"default:sand", "default:silver_sand", "default:desert_sand"},
@@ -935,7 +942,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Scoria
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:scoria",
 		wherein         = {"default:stone", "default:desert_stone"},
@@ -955,7 +962,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Serpentine
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:serpentine",
 		wherein         = {"default:stone"},
@@ -975,7 +982,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Slate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:slate",
 		wherein         = {"default:stone"},
@@ -995,7 +1002,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Smokey Quartz
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:smokey_quartz",
 		wherein         = {"default:sandstone"},
@@ -1015,7 +1022,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Soapstone
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:soapstone",
 		wherein         = {"default:sandstone"},
@@ -1033,7 +1040,7 @@ if minetest.get_modpath("default") ~= nil then
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:soapstone",
 		wherein         = {"default:stone"},
@@ -1053,7 +1060,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Sodalite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:sodalite",
 		wherein         = {"default:stone", "default:desert_stone"},
@@ -1073,7 +1080,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Sugilite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:sugilite",
 		wherein         = {"default:stone"},
@@ -1093,7 +1100,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Travertine
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:travertine",
 		wherein         = {"default:stone"},
@@ -1111,7 +1118,7 @@ if minetest.get_modpath("default") ~= nil then
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:travertine",
 		wherein         = {"default:sandstone"},
@@ -1131,7 +1138,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Turquoise
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:sandstone_with_turquoise",
 		wherein         = {"default:sandstone"},
@@ -1150,7 +1157,7 @@ if minetest.get_modpath("default") ~= nil then
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:desert_sandstone_with_turquoise",
 		wherein         = {"default:desert_sandstone"},
@@ -1169,7 +1176,7 @@ if minetest.get_modpath("default") ~= nil then
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:silver_sandstone_with_turquoise",
 		wherein         = {"default:silver_sandstone"},
@@ -1190,7 +1197,7 @@ if minetest.get_modpath("default") ~= nil then
 
 -- Vivianite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:vivianite",
 		wherein         = {"default:stone", "default:silver_sandstone"},
@@ -1216,7 +1223,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Blue Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_blue",
 		wherein         = {"base_earth:stone"},
@@ -1236,7 +1243,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Gray Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_gray",
 		wherein         = {"base_earth:stone"},
@@ -1256,7 +1263,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Green Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_green",
 		wherein         = {"base_earth:stone"},
@@ -1276,7 +1283,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Moss Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_moss",
 		wherein         = {"base_earth:stone"},
@@ -1296,7 +1303,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Orange Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_orange",
 		wherein         = {"base_earth:stone"},
@@ -1316,7 +1323,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Purple Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_purple",
 		wherein         = {"base_earth:stone"},
@@ -1336,7 +1343,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Red Agate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:agate_red",
 		wherein         = {"base_earth:stone"},
@@ -1356,7 +1363,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Amazonite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:amazonite",
 		wherein         = {"base_earth:stone"},
@@ -1376,7 +1383,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Amber
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:amber",
 		wherein         = {"base_earth:stone"},
@@ -1396,7 +1403,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Amethyst
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:amethyst",
 		wherein         = {"base_earth:stone"},
@@ -1414,7 +1421,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:amethyst",
 		wherein         = {"base_earth:stone"},
@@ -1434,7 +1441,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Basalt
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:basalt",
 		wherein         = {"base_earth:stone"},
@@ -1454,7 +1461,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Columnar Basalt
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:basalt_columnar",
 		wherein         = {"base_earth:stone"},
@@ -1475,7 +1482,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Calcite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:calcite",
 		wherein         = {"base_earth:stone"},
@@ -1494,7 +1501,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:calcite",
 		wherein         = {"base_earth:sand", "base_earth:silver_sand"},
@@ -1515,7 +1522,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Carnotite
 
-		minetest.register_ore({
+		register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:carnotite",
 		wherein         = {"base_earth:stone", "base_earth:desert_stone"},
@@ -1535,7 +1542,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Celestine
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:celestine",
 		wherein         = {"base_earth:silver_sandstone"},
@@ -1555,7 +1562,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Citrine
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:citrine",
 		wherein         = {"base_earth:desert_stone"},
@@ -1575,7 +1582,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Eudialite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:eudialite",
 		wherein         = {"base_earth:stone"},
@@ -1595,7 +1602,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Gabbro
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:gabbro",
 		wherein         = {"base_earth:stone"},
@@ -1615,7 +1622,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Galena
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:galena",
 		wherein         = {"base_earth:stone", "base_earth:sandstone", "base_earth:desert_sandstone"},
@@ -1635,7 +1642,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Black Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_black",
 		wherein         = {"base_earth:stone"},
@@ -1655,7 +1662,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Blue Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_blue",
 		wherein         = {"base_earth:stone"},
@@ -1675,7 +1682,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Gray Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_gray",
 		wherein         = {"base_earth:stone"},
@@ -1695,7 +1702,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Green Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_green",
 		wherein         = {"base_earth:stone"},
@@ -1716,7 +1723,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Pink Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_pink",
 		wherein         = {"base_earth:stone"},
@@ -1736,7 +1743,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Red Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_red",
 		wherein         = {"base_earth:stone", "base_earth:desert_stone"},
@@ -1757,7 +1764,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- White Granite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:granite_white",
 		wherein         = {"base_earth:stone"},
@@ -1777,7 +1784,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Heliodor
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:heliodor",
 		wherein         = {"base_earth:stone"},
@@ -1797,7 +1804,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Howlite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:howlite",
 		wherein         = {"base_earth:stone", "base_earth:silver_sandstone", "base_earth:desert_sandstone"},
@@ -1817,7 +1824,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Ilvaite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:ilvaite",
 		wherein         = {"base_earth:stone", "base_earth:desert_stone", "base_earth:permafrost"},
@@ -1837,7 +1844,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Kyanite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:kyanite",
 		wherein         = {"base_earth:stone"},
@@ -1855,7 +1862,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:kyanite",
 		wherein         = {"base_earth:silver_sand"},
@@ -1875,7 +1882,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Lapis Lazuli
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:lapis_lazuli",
 		wherein         = {"base_earth:sandstone", "base_earth:desert_stone", "base_earth:silver_sandstone"},
@@ -1895,7 +1902,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Blue Limestone
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:limestone_blue",
 		wherein         = {"base_earth:stone", "base_earth:sand", "base_earth:desert_sand"},
@@ -1915,7 +1922,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- White Limestone
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:limestone_white",
 		wherein         = {"base_earth:stone", "base_earth:silver_sand"},
@@ -1935,7 +1942,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Marble
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:marble",
 		wherein         = {"base_earth:stone", "base_earth:sandstone", "base_earth:silver_sandstone"},
@@ -1956,7 +1963,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Mudstone
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:mudstone",
 		wherein         = {"base_earth:stone"},
@@ -1976,7 +1983,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Prasiolite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:prasiolite",
 		wherein         = {"base_earth:stone", "base_earth:silver_sandstone"},
@@ -1994,7 +2001,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:prasiolite",
 		wherein         = {"base_earth:sand", "base_earth:silver_sand", "base_earth:desert_sand"},
@@ -2014,7 +2021,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Pumice
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:pumice",
 		wherein         = {"base_earth:stone", "base_earth:gravel"},
@@ -2032,7 +2039,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:pumice",
 		wherein         = {"base_liquids:water_source"},
@@ -2052,7 +2059,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Quartz
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:quartz",
 		wherein         = {"base_earth:stone", "base_earth:desert_stone"},
@@ -2070,7 +2077,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:quartz",
 		wherein         = {"base_earth:sand", "base_earth:silver_sand", "base_earth:desert_sand"},
@@ -2090,7 +2097,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Rose Quartz
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:rose_quartz",
 		wherein         = {"base_earth:stone", "base_earth:desert_stone"},
@@ -2108,7 +2115,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:rose_quartz",
 		wherein         = {"base_earth:sand", "base_earth:silver_sand", "base_earth:desert_sand"},
@@ -2128,7 +2135,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Scoria
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:scoria",
 		wherein         = {"base_earth:stone", "base_earth:desert_stone"},
@@ -2148,7 +2155,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Serpentine
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:serpentine",
 		wherein         = {"base_earth:stone"},
@@ -2168,7 +2175,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Slate
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:slate",
 		wherein         = {"base_earth:stone"},
@@ -2188,7 +2195,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Smokey Quartz
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:smokey_quartz",
 		wherein         = {"base_earth:sandstone"},
@@ -2208,7 +2215,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Soapstone
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:soapstone",
 		wherein         = {"base_earth:sandstone"},
@@ -2226,7 +2233,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:soapstone",
 		wherein         = {"base_earth:stone"},
@@ -2246,7 +2253,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Sodalite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:sodalite",
 		wherein         = {"base_earth:stone", "base_earth:desert_stone"},
@@ -2266,7 +2273,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Sugilite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:sugilite",
 		wherein         = {"base_earth:stone"},
@@ -2286,7 +2293,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Travertine
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:travertine",
 		wherein         = {"base_earth:stone"},
@@ -2304,7 +2311,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:travertine",
 		wherein         = {"base_earth:sandstone"},
@@ -2324,7 +2331,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Turquoise
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:sandstone_with_turquoise",
 		wherein         = {"base_earth:sandstone"},
@@ -2343,7 +2350,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:desert_sandstone_with_turquoise",
 		wherein         = {"base_earth:desert_sandstone"},
@@ -2362,7 +2369,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 		},
 	})
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:silver_sandstone_with_turquoise",
 		wherein         = {"base_earth:silver_sandstone"},
@@ -2383,7 +2390,7 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 
 -- Vivianite
 
-	minetest.register_ore({
+	register_ore_by_climate({
 		ore_type        = "blob",
 		ore             = "too_many_stones:vivianite",
 		wherein         = {"base_earth:stone", "base_earth:silver_sandstone"},
@@ -2402,3 +2409,63 @@ if minetest.get_modpath("base_earth") and minetest.get_modpath("base_liquids") ~
 	})
 
 end
+
+-- Do actual ore registration after all mods are loaded
+minetest.register_on_mods_loaded(function()
+	for _,ore in ipairs(oreq) do
+		-- Initialize any missing biome or climate values
+		ore.biomes = ore.biomes or {}
+
+		local checksum = 0
+		if not ore.heat_min then
+			ore.heat_min = -100
+			checksum = checksum + 1
+		end
+
+		if not ore.heat_max then
+			ore.heat_max = 200
+			checksum = checksum + 1
+		end
+
+		if not ore.humidity_min then
+			ore.humidity_min = -100
+			checksum = checksum + 1
+		end
+
+		if not ore.humidity_max then
+			ore.humidity_max = 200
+			checksum = checksum + 1
+		end
+
+		-- Add matching biomes to ore biome list if any climate data was specified
+		if checksum ~= 4 then
+			checksum = #ore.biomes
+			for name,biome in pairs(minetest.registered_biomes) do
+				-- Increment biome checksum
+				checksum = checksum + 1
+
+				-- Ensure climate values
+				local heat = biome.heat_point or 50
+				local humidity = biome.humidity_point or 50
+
+				-- Add biome if climate values match
+				if (
+					heat >= ore.heat_min and
+					heat <= ore.heat_max and
+					humidity >= ore.humidity_min and
+					humidity <= ore.humidity_max
+				) then
+					table.insert(ore.biomes,name)
+				end
+			end
+		else
+			checksum = #ore.biomes + 1
+		end
+
+		-- Don't use an empty biome list or a biome list that contains all biomes
+		ore.biomes = #ore.biomes > 0 and #ore.biomes < checksum and ore.biomes or nil
+
+		-- Register ore with Minetest
+		minetest.register_ore(ore)
+	end
+end)


### PR DESCRIPTION
Implements a new mechanism for registering TMS stones by climate. The ore definitions are queued up until after all other mods are loaded then uses the following extra values in each ore definition to identify which biomes the stone should appear in:

- `heat_min` - biomes must have a `heat_point` of at least this value
- `heat_max` - biomes must not have a `heat_point` higher than this value
- `humidity_min` - biomes must have a `humidity_point` of at least this value
- `humidity_max` - biomes must not have a `humidity_point` higher than this value